### PR TITLE
feat(AppWindow): disable 'select odd pages' & 'select even pages' actions in corner cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ src/backend/config.hpp
 build-aux/.flatpak-builder/
 build-aux/.pdfslicer/
 build-aux/pdfslicer-repo/
+.vscode

--- a/src/application/application.cpp
+++ b/src/application/application.cpp
@@ -98,7 +98,7 @@ void Application::on_open(const Application::type_vec_files& files,
 {
     for (const Glib::RefPtr<Gio::File>& file : files) {
         AppWindow* window = createWindow();
-        window->setDocument(std::make_unique<Document>(file));
+        window->setDocument(std::make_unique<Document>(files));
         window->present();
     }
 }

--- a/src/application/appwindow.cpp
+++ b/src/application/appwindow.cpp
@@ -573,10 +573,10 @@ void AppWindow::onSelectedPagesChanged()
     const unsigned long numSelected = indexSelected.size();
     const unsigned long numPages = m_document->numberOfPages();
 
-    const bool is_odd_pages_action_enabled = numPages > 0;
-    const bool is_even_pages_action_enabled = numPages > 1;
-    m_selectOddPagesAction->set_enabled(is_odd_pages_action_enabled);
-    m_selectEvenPagesAction->set_enabled(is_even_pages_action_enabled);
+    const bool isOddPagesActionEnabled = numPages > 0;
+    const bool isEvenPagesActionEnabled = numPages > 1;
+    m_selectOddPagesAction->set_enabled(isOddPagesActionEnabled);
+    m_selectEvenPagesAction->set_enabled(isEvenPagesActionEnabled);
 
     if (numSelected == 0) {
         m_removeSelectedAction->set_enabled(false);

--- a/src/application/appwindow.cpp
+++ b/src/application/appwindow.cpp
@@ -213,13 +213,13 @@ void AppWindow::setupSignalHandlers()
 
     m_savedDispatcher.connect([this]() {
         m_savingRevealer.saved();
-        enableEditingActions();
+        m_saveAction->set_enabled(true);
         setModified(false);
     });
 
     m_savingFailedDispatcher.connect([this]() {
         m_savingRevealer.set_reveal_child(false);
-        enableEditingActions();
+        m_saveAction->set_enabled(true);
         showSaveFileFailedErrorDialog();
     });
 
@@ -251,31 +251,6 @@ void AppWindow::loadCustomCSS()
     Gtk::StyleContext::add_provider_for_screen(screen,
                                                provider,
                                                GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
-}
-
-void AppWindow::disableEditingActions()
-{
-    m_openAction->set_enabled(false);
-    m_saveAction->set_enabled(false);
-    m_undoAction->set_enabled(false);
-    m_redoAction->set_enabled(false);
-    m_removeSelectedAction->set_enabled(false);
-    m_removeUnselectedAction->set_enabled(false);
-    m_removePreviousAction->set_enabled(false);
-    m_removeNextAction->set_enabled(false);
-    m_rotateRightAction->set_enabled(false);
-    m_rotateLeftAction->set_enabled(false);
-    m_moveLeftAction->set_enabled(false);
-    m_moveRightAction->set_enabled(false);
-    m_cancelSelectionAction->set_enabled(false);
-}
-
-void AppWindow::enableEditingActions()
-{
-    m_openAction->set_enabled();
-    m_saveAction->set_enabled();
-    onSelectedPagesChanged();
-    onCommandExecuted();
 }
 
 void AppWindow::onAboutAction()
@@ -336,7 +311,7 @@ bool AppWindow::saveFileInForeground(const Glib::RefPtr<Gio::File>& file)
 void AppWindow::saveFileInBackground(const Glib::RefPtr<Gio::File>& file)
 {
     m_savingRevealer.saving();
-    disableEditingActions();
+    m_saveAction->set_enabled(false);
     m_isSavingDocument = true;
 
     std::thread thread{[this, file]() {

--- a/src/application/appwindow.cpp
+++ b/src/application/appwindow.cpp
@@ -598,6 +598,11 @@ void AppWindow::onSelectedPagesChanged()
     const unsigned long numSelected = indexSelected.size();
     const unsigned long numPages = m_document->numberOfPages();
 
+    const bool is_odd_pages_action_enabled = numPages > 0;
+    const bool is_even_pages_action_enabled = numPages > 1;
+    m_selectOddPagesAction->set_enabled(is_odd_pages_action_enabled);
+    m_selectEvenPagesAction->set_enabled(is_even_pages_action_enabled);
+
     if (numSelected == 0) {
         m_removeSelectedAction->set_enabled(false);
         m_removeUnselectedAction->set_enabled(false);

--- a/src/application/appwindow.hpp
+++ b/src/application/appwindow.hpp
@@ -122,8 +122,6 @@ private:
     void addActions();
     void setupWidgets();
     void setupSignalHandlers();
-    void disableEditingActions();
-    void enableEditingActions();
     bool showSaveFileDialogAndSave(SaveFileIn howToSave);
     bool saveFileInForeground(const Glib::RefPtr<Gio::File>& file);
     void saveFileInBackground(const Glib::RefPtr<Gio::File>& file);

--- a/src/backend/document.cpp
+++ b/src/backend/document.cpp
@@ -31,6 +31,13 @@ Document::Document(const Glib::RefPtr<Gio::File>& sourceFile)
     m_filesData.emplace_back(std::move(fileData));
 }
 
+Document::Document(const std::vector<Glib::RefPtr<Gio::File>>& sourceFiles) : Document(sourceFiles[0])
+{
+    std::vector<Glib::RefPtr<Gio::File>> additional_files(sourceFiles.size() - 1);
+    std::copy(sourceFiles.begin() + 1, sourceFiles.end(), additional_files.begin());
+    addFiles(additional_files, m_pages->get_n_items());
+}
+
 Glib::RefPtr<Page> Document::removePage(unsigned int index)
 {
     Glib::RefPtr<Page> removedPage = m_pages->get_item(index);

--- a/src/backend/document.hpp
+++ b/src/backend/document.hpp
@@ -22,12 +22,14 @@
 #include <giomm/file.h>
 #include <giomm/liststore.h>
 #include <poppler/cpp/poppler-document.h>
+#include <vector>
 
 namespace Slicer {
 
 class Document {
 public:
     Document(const Glib::RefPtr<Gio::File>& sourceFile);
+    Document(const std::vector<Glib::RefPtr<Gio::File>>& sourceFiles);
 
     Glib::RefPtr<Page> removePage(unsigned int index);
     std::vector<Glib::RefPtr<Page>> removePages(const std::vector<unsigned int>& indexes);


### PR DESCRIPTION
Resolves #117 