### PR TITLE
feat(AppWindow): disable 'select odd pages' & 'select even pages' actions in corner cases

### DIFF
--- a/src/application/appwindow.cpp
+++ b/src/application/appwindow.cpp
@@ -573,6 +573,11 @@ void AppWindow::onSelectedPagesChanged()
     const unsigned long numSelected = indexSelected.size();
     const unsigned long numPages = m_document->numberOfPages();
 
+    const bool isOddPagesActionEnabled = numPages > 0;
+    const bool isEvenPagesActionEnabled = numPages > 1;
+    m_selectOddPagesAction->set_enabled(isOddPagesActionEnabled);
+    m_selectEvenPagesAction->set_enabled(isEvenPagesActionEnabled);
+
     if (numSelected == 0) {
         m_removeSelectedAction->set_enabled(false);
         m_removeUnselectedAction->set_enabled(false);


### PR DESCRIPTION
Resolves #117