### PR TITLE
Add keyboard shortcuts to move pages

### DIFF
--- a/data/ui/shortcuts.ui
+++ b/data/ui/shortcuts.ui
@@ -93,6 +93,18 @@
 								<property name="title" translatable="yes" context="shortcut window">Redo undone command</property>
 							</object>
 						</child>
+						<child>
+							<object class="GtkShortcutsShortcut">
+								<property name="accelerator">&lt;ctrl&gt;Left</property>
+								<property name="title" translatable="yes" context="shortcut window">Move selected pages left</property>
+							</object>
+						</child>
+						<child>
+							<object class="GtkShortcutsShortcut">
+								<property name="accelerator">&lt;ctrl&gt;Right</property>
+								<property name="title" translatable="yes" context="shortcut window">Move selected pages right</property>
+							</object>
+						</child>
 					</object>
 				</child>
 			</object>

--- a/src/application/application.cpp
+++ b/src/application/application.cpp
@@ -78,6 +78,9 @@ void Application::addAccels()
     set_accel_for_action("win.reset-zoom", "<Control>0");
     set_accel_for_action("win.close-window", "<Control>q");
 
+    set_accel_for_action("win.move-right", "<Control>Right");
+    set_accel_for_action("win.move-left", "<Control>Left");
+
     // FIXME: The following actions don't work
     set_accels_for_action("preview.zoom-in",
                           {"<Control>plus", "<Control>KP_Add"});


### PR DESCRIPTION
Adds the Ctrl+left and right arrow keys to move around pages.

#202 