### PR TITLE
docs(metainfo): Add link to source repo

### DIFF
--- a/data/com.github.junrrein.PDFSlicer.appdata.xml.in
+++ b/data/com.github.junrrein.PDFSlicer.appdata.xml.in
@@ -15,6 +15,7 @@
 		</_p>
 	</description>
 	<url type="homepage">@APPLICATION_WEBSITE@</url>
+    <url type="vcs-browser">https://github.com/junrrein/pdfslicer</url>
 	<url type="bugtracker">https://github.com/junrrein/pdfslicer/issues</url>
 	<url type="translate">https://hosted.weblate.org/projects/pdf-slicer/</url>
 	<developer_name>Julián Unrrein</developer_name>


### PR DESCRIPTION
cf. https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines#url