### PR TITLE
Set prgname to application ID

### DIFF
--- a/src/application/application.cpp
+++ b/src/application/application.cpp
@@ -32,6 +32,7 @@ Application::Application()
     : Gtk::Application(config::APPLICATION_ID, Gio::APPLICATION_HANDLES_OPEN)
 {
     Glib::set_application_name(config::APPLICATION_NAME);
+    Glib::set_prgname(config::APPLICATION_ID);
 }
 
 void Application::addActions()


### PR DESCRIPTION
Using the application ID ensures that Wayland compositors could match the window with the application and show the appropriate icon for them.

References:
- https://honk.sigxcpu.org/con/GTK__and_the_application_id.html
- https://docs.gtk.org/gtk4/migrating-3to4.html#set-a-proper-application-id